### PR TITLE
feat: Record 추가 및 모달 관리 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "@ant-design/icons": "~5.6.1",
     "@ant-design/v5-patch-for-react-19": "^1.0.3",
     "antd": "^5.24.9",
+    "dayjs": "^1.11.13",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router": "^7.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       antd:
         specifier: ^5.24.9
         version: 5.24.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      dayjs:
+        specifier: ^1.11.13
+        version: 1.11.13
       react:
         specifier: ^19.0.0
         version: 19.1.0

--- a/src/context/ModalOverlayProvider.tsx
+++ b/src/context/ModalOverlayProvider.tsx
@@ -1,0 +1,35 @@
+import { createContext, useCallback, useMemo, useState } from 'react';
+import ReactDOM from 'react-dom';
+
+type ModalComponent = React.ReactElement | null;
+
+interface ModalOverlayContextValue {
+  open: (render: (props: { isOpen: boolean; close: () => void }) => React.ReactElement) => void;
+  close: () => void;
+}
+
+export const ModalOverlayContext = createContext<ModalOverlayContextValue | null>(null);
+
+export function ModalOverlayProvider({ children }: { children: React.ReactNode }) {
+  const [modal, setModal] = useState<ModalComponent>(null);
+
+  const close = useCallback(() => {
+    setModal(null);
+  }, []);
+
+  const open = useCallback(
+    (render: (props: { isOpen: boolean; close: () => void }) => React.ReactElement) => {
+      setModal(render({ isOpen: true, close }));
+    },
+    [close],
+  );
+
+  const contextValue = useMemo(() => ({ open, close }), [open, close]);
+
+  return (
+    <ModalOverlayContext.Provider value={contextValue}>
+      {children}
+      {modal && ReactDOM.createPortal(modal, document.body)}
+    </ModalOverlayContext.Provider>
+  );
+}

--- a/src/hooks/useModalOverlay.ts
+++ b/src/hooks/useModalOverlay.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { ModalOverlayContext } from '../context/ModalOverlayProvider';
+
+export function useModalOverlay() {
+  const context = useContext(ModalOverlayContext);
+  if (!context) throw new Error('useModalOverlay must be used within ModalOverlayProvider');
+  return context;
+}

--- a/src/pages/RecordsPage/components/RecordHeader.tsx
+++ b/src/pages/RecordsPage/components/RecordHeader.tsx
@@ -3,10 +3,12 @@ import { PlusOutlined } from '@ant-design/icons';
 
 import { StyledHeader, Title } from './recodeHeader.styles';
 import { useRecordActions, useRecordState } from '../context/RecordContext';
+import { useRecordFormModal } from '../hooks/useRecordFormModal';
 
 export default function RecordHeader() {
   const { selectedRowKeys } = useRecordState();
   const { deleteSelectedRecords } = useRecordActions();
+  const { open } = useRecordFormModal();
   return (
     <StyledHeader>
       <Space size={8}>
@@ -17,7 +19,7 @@ export default function RecordHeader() {
           </Button>
         )}
       </Space>
-      <Button type="primary" icon={<PlusOutlined />}>
+      <Button type="primary" icon={<PlusOutlined />} onClick={() => open('add')}>
         추가
       </Button>
     </StyledHeader>

--- a/src/pages/RecordsPage/components/recordTable.styles.ts
+++ b/src/pages/RecordsPage/components/recordTable.styles.ts
@@ -3,29 +3,37 @@ import styled from 'styled-components';
 import { Record } from '../types';
 
 export const StyledTable = styled(Table)<TableProps<Record>>`
-  && .ant-table-container {
-    border-top: 1px solid #0000000f;
-    border-radius: 0;
-  }
-  && .ant-table-thead .ant-table-cell {
-    padding-left: 8px;
-    padding-top: 8px;
-    padding-bottom: 8px;
-  }
-  && .ant-table-tbody .ant-table-cell {
-    padding: 8px;
-  }
-  && .ant-table-filter-column {
-    display: flex;
-    align-items: center;
-  }
-  && .ant-table-filter-trigger {
-    height: 22px;
-    align-items: center;
-    justify-content: center;
-  }
-  && .ant-table-tbody .ant-table-selection-column {
-    border-right: 1px solid #0000000f;
+  && {
+    .ant-table-container {
+      border-top: 1px solid #0000000f;
+      border-radius: 0;
+    }
+
+    .ant-table-thead .ant-table-cell {
+      padding-left: 8px;
+      padding-top: 8px;
+      padding-bottom: 8px;
+    }
+
+    .ant-table-tbody .ant-table-cell {
+      padding: 8px;
+    }
+
+    .ant-table-filter-column {
+      display: flex;
+      align-items: center;
+    }
+
+    .ant-table-filter-trigger {
+      height: 22px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .ant-table-tbody .ant-table-selection-column {
+      border-right: 1px solid #0000000f;
+    }
   }
 `;
 

--- a/src/pages/RecordsPage/hooks/recordFormModal.styles.tsx
+++ b/src/pages/RecordsPage/hooks/recordFormModal.styles.tsx
@@ -1,0 +1,136 @@
+import styled from 'styled-components';
+import { Modal, Form, Input, DatePicker, Select, FormProps } from 'antd';
+import { RecordFormType } from '../types';
+
+const { TextArea } = Input;
+
+export const StyledModal = styled(Modal)`
+  && {
+    .ant-modal-content {
+      padding: 12px 0;
+      box-shadow: 0px 9px 28px 8px #0000000d;
+    }
+
+    .ant-modal-header {
+      padding: 0 16px 12px;
+      border-bottom: 1px solid #f0f0f0;
+      margin-bottom: 10px;
+    }
+
+    .ant-modal-title {
+      font-size: 14px;
+      line-height: 22px;
+    }
+
+    .ant-modal-close {
+      width: 22px;
+      height: 22px;
+    }
+
+    .ant-modal-footer {
+      border-top: 1px solid #0000000f;
+      display: flex;
+      justify-content: flex-end;
+      background-color: #00000005;
+      padding: 12px 16px 0;
+    }
+  }
+`;
+
+export const StyledForm = styled(Form)<FormProps<RecordFormType>>`
+  && {
+    .ant-form-item {
+      padding: 0 24px;
+      margin-bottom: 20px;
+    }
+
+    .ant-form-item-label > label {
+      color: #00000073;
+      font-size: 16px;
+      line-height: 24px;
+      font-weight: 600;
+    }
+
+    .ant-form-item-explain-error {
+      font-size: 12px;
+      line-height: 18px;
+    }
+    .ant-form-item-control-input {
+      min-height: 0;
+    }
+  }
+  &&& {
+    .ant-form-item-label {
+      min-height: 40px;
+      padding: 0;
+      display: flex;
+      align-items: center;
+    }
+  }
+`;
+
+export const RequiredMark = styled.div`
+  display: flex;
+  gap: 4px;
+
+  & > span {
+    font-size: 16px;
+    font-weight: 400;
+    color: #ff4d4f;
+  }
+`;
+
+export const StyledInput = styled(Input)`
+  && {
+    height: 32px;
+    font-size: 14px;
+    line-height: 22px;
+    font-weight: 400;
+    border-radius: 8px;
+    padding: 0 12px;
+    border: 1px solid #e3e3e3;
+  }
+`;
+
+export const StyledTextArea = styled(TextArea)`
+  && {
+    height: 64px;
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 400;
+    border-radius: 10px;
+    padding: 5px 12px;
+  }
+`;
+
+export const StyledDatePicker = styled(DatePicker)`
+  && {
+    width: 162px;
+    height: 32px;
+    border-radius: 8px;
+    padding: 0 12px;
+
+    .ant-picker-input > input {
+      font-size: 14px;
+      line-height: 22px;
+      font-weight: 400;
+    }
+  }
+`;
+
+export const StyledSelect = styled(Select)`
+  && {
+    width: 100px;
+    .ant-select-selector {
+      height: 32px;
+      font-size: 14px;
+      line-height: 22px;
+      font-weight: 400;
+      border-radius: 8px;
+    }
+
+    .ant-select-arrow {
+      color: #000000e0;
+    }
+  }
+`;

--- a/src/pages/RecordsPage/hooks/useRecordFormModal.tsx
+++ b/src/pages/RecordsPage/hooks/useRecordFormModal.tsx
@@ -1,0 +1,147 @@
+import { useMemo, useEffect, useState } from 'react';
+import { useModalOverlay } from '../../../hooks/useModalOverlay';
+import { useRecordActions } from '../context/RecordContext';
+import {
+  StyledModal,
+  StyledForm,
+  StyledInput,
+  StyledTextArea,
+  StyledDatePicker,
+  StyledSelect,
+  RequiredMark,
+} from './recordFormModal.styles';
+import { Record, RecordFormType } from '../types';
+import { Checkbox, Form, Select } from 'antd';
+import dayjs, { type Dayjs } from 'dayjs';
+
+type FormMode = 'add' | 'edit';
+
+export function useRecordFormModal() {
+  const overlay = useModalOverlay();
+
+  return useMemo(
+    () => ({
+      open: (mode: FormMode, record?: Record) =>
+        overlay.open(({ isOpen, close }) => (
+          <RecordFormModal open={isOpen} close={close} mode={mode} record={record} />
+        )),
+      close: overlay.close,
+    }),
+    [overlay],
+  );
+}
+
+const { Option } = Select;
+
+interface RecordFormModalProps {
+  open: boolean;
+  close: () => void;
+  mode: FormMode;
+  record?: Record;
+}
+
+const initialValues = {
+  name: '',
+  address: null,
+  memo: null,
+  joinDate: null,
+  job: '개발자',
+  emailConsent: false,
+};
+
+// TODO: (mode = 'edit') 로직 추가
+function RecordFormModal({ open, close, mode, record }: RecordFormModalProps) {
+  const { addRecord } = useRecordActions();
+
+  const [form] = Form.useForm<RecordFormType>();
+  const values = Form.useWatch([], form);
+  const [isFormValid, setIsFormValid] = useState<boolean>(false);
+
+  // * 유효성 체크
+  useEffect(() => {
+    form
+      .validateFields({ validateOnly: true })
+      .then(() => setIsFormValid(true))
+      .catch(() => setIsFormValid(false));
+  }, [form, values]);
+
+  const handleFinish = (values: RecordFormType) => {
+    const finalValues = {
+      ...values,
+      joinDate: dayjs(values.joinDate).format('YYYY-MM-DD'),
+      address: values.address || null,
+      memo: values.memo || null,
+    };
+    addRecord(finalValues);
+
+    form.resetFields();
+    close();
+  };
+
+  // * 오늘 이후 날짜 비활성화
+  const disabledDate = (current: Dayjs) => {
+    return current && current.isAfter(dayjs(), 'day');
+  };
+
+  // * 마커 오른쪽 표기용
+  const customizeRequiredMark = (label: React.ReactNode, { required }: { required: boolean }) => (
+    <RequiredMark>
+      {label}
+      {required && <span>*</span>}
+    </RequiredMark>
+  );
+
+  return (
+    <StyledModal
+      title="회원 추가"
+      open={open}
+      onCancel={close}
+      onOk={() => {
+        form.submit();
+      }}
+      okText="저장"
+      cancelText="취소"
+      width={520}
+      okButtonProps={{ disabled: !isFormValid }}
+    >
+      <StyledForm
+        form={form}
+        layout="vertical"
+        onFinish={handleFinish}
+        style={{ marginBottom: 16 }}
+        requiredMark={customizeRequiredMark}
+        initialValues={initialValues}
+      >
+        <Form.Item
+          name="name"
+          label="이름"
+          rules={[
+            { required: true, message: '이름을 입력하세요' },
+            { max: 20, message: '글자수 20을 초과할 수 없습니다.' },
+          ]}
+        >
+          <StyledInput />
+        </Form.Item>
+        <Form.Item name="address" label="주소" rules={[{ max: 20, message: '글자수 20을 초과할 수 없습니다.' }]}>
+          <StyledInput />
+        </Form.Item>
+        <Form.Item name="memo" label="메모" rules={[{ max: 50, message: '글자수 50을 초과할 수 없습니다.' }]}>
+          <StyledTextArea />
+        </Form.Item>
+        <Form.Item name="joinDate" label="가입일" rules={[{ required: true, message: '가입일을 선택하세요' }]}>
+          <StyledDatePicker showNow={false} format="YYYY-MM-DD" disabledDate={disabledDate} />
+        </Form.Item>
+        <Form.Item name="job" label="직업">
+          <StyledSelect>
+            <Option value="개발자">개발자</Option>
+            <Option value="PO">PO</Option>
+            <Option value="디자이너">디자이너</Option>
+          </StyledSelect>
+        </Form.Item>
+        <Form.Item name="emailConsent" label="이메일 수신 동의" valuePropName="checked">
+          <Checkbox />
+        </Form.Item>
+      </StyledForm>
+    </StyledModal>
+  );
+}

--- a/src/pages/RecordsPage/index.tsx
+++ b/src/pages/RecordsPage/index.tsx
@@ -1,3 +1,4 @@
+import { ModalOverlayProvider } from '../../context/ModalOverlayProvider';
 import RecordHeader from './components/RecordHeader';
 import RecordTable from './components/RecordTable';
 import { RecordProvider } from './context/RecordContext';
@@ -5,8 +6,10 @@ import { RecordProvider } from './context/RecordContext';
 export function RecordsPage() {
   return (
     <RecordProvider>
-      <RecordHeader />
-      <RecordTable />
+      <ModalOverlayProvider>
+        <RecordHeader />
+        <RecordTable />
+      </ModalOverlayProvider>
     </RecordProvider>
   );
 }

--- a/src/pages/RecordsPage/types.ts
+++ b/src/pages/RecordsPage/types.ts
@@ -1,3 +1,5 @@
+import { type Dayjs } from 'dayjs';
+
 export type JobType = '개발자' | 'PO' | '디자이너';
 
 export interface Record {
@@ -5,7 +7,11 @@ export interface Record {
   name: string;
   address: string | null;
   memo: string | null;
-  joinDate: string;
+  joinDate: string | null;
   job: JobType;
   emailConsent: boolean;
 }
+
+export type RecordFormType = Omit<Record, 'id' | 'joinDate'> & {
+  joinDate: Dayjs | null;
+};


### PR DESCRIPTION
- ModalOverlayProvider와 useRecordFormModal 훅을 사용하여 모달 상태를 중앙 관리하도록 구현했습니다.
- antd Modal의 UI 기능을 활용하면서 상태 관리를 컨텍스트로 통합하여 코드 복잡성을 줄이고 재사용성을 높였습니다.
- useRecordFormModal: useModalOverlay 훅을 사용하여 모달 상태를 컨텍스트 기반으로 관리합니다.
- RecordFormModal에서 'add' Mode를 통해 Record를 생성하는 기능 구현

### Todo
- [x] 'edit' Mode 로직 구현